### PR TITLE
Add missing scrub context for enemies when they are configured.

### DIFF
--- a/combatengine.js
+++ b/combatengine.js
@@ -189,6 +189,8 @@ let configureEnemy = async function (state, target, flavor) {
     console.log(`Configured enemy: ${JSON.stringify(enemy)}`);
 
     state.enemy = enemy;
+    state.contextTags = enemy.tags;
+    state.contextScrubbers = enemy.scrubbers;
 
     let announce = targetDef[`${flavor} announce`];
     state.enemy.tell = targetDef.cardsets[enemy.cardqueue[0].set].tell;


### PR DESCRIPTION
Fix an issue where the context scrubbers have no context when a fight starts. This was causing nagas to show generic they/them/their in the intro text, for example, when it should show gendered pronouns.